### PR TITLE
Fixed unclosed <string> entry

### DIFF
--- a/swift.plist
+++ b/swift.plist
@@ -278,7 +278,7 @@
 		<string>AbsoluteValuable</string>
 		<string>AnyObject</string>
 		<string>BidirectionalCollection</string>
-		<string>BidirectionalIndexable/string>
+		<string>BidirectionalIndexable</string>
 		<string>BinaryFloatingPoint</string>
 		<string>BitwiseOperations</string>
 		<string>Collection</string>


### PR DESCRIPTION
The </string> tag on line 281 was mistyped, which made the plist
invalid and prevented the language module from loading.